### PR TITLE
Updated import of six in operations.py

### DIFF
--- a/djongo/operations.py
+++ b/djongo/operations.py
@@ -1,8 +1,9 @@
 import pytz
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
-from django.utils import six, timezone
+from django.utils import timezone
 import datetime, calendar
+import six
 
 
 class DatabaseOperations(BaseDatabaseOperations):


### PR DESCRIPTION
django.utils.six removed from Django 3.0. New patch requires importing six independently.